### PR TITLE
BUGFIX: include swipestripe-addresses as a dependency as its required by...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 	{
 		"silverstripe/framework": "~3.1",
 		"silverstripe/cms": "~3.1",
-		"swipestripe/swipestripe": "2.1.*"
+		"swipestripe/swipestripe": "2.1.*",
+		"swipestripe/swipestripe-addresses": "2.1.*"
 	},
 	"support": 
 	{


### PR DESCRIPTION
... the default SWS yaml file
